### PR TITLE
Add support for rails '//= require rails-ujs' syntax

### DIFF
--- a/base/index.js
+++ b/base/index.js
@@ -324,7 +324,7 @@ module.exports = {
     ],
     'space-unary-ops': 1,
     'spaced-comment': [
-      2, 'always'
+      2, 'always', { 'markers': ['='] }
     ],
     'wrap-regex': 2,
 


### PR DESCRIPTION
This rule fix allows `//= require rails-ujs` syntax.